### PR TITLE
Support different interfaces for RAID devices

### DIFF
--- a/src/perfTest/Devices.py
+++ b/src/perfTest/Devices.py
@@ -698,6 +698,7 @@ class RAID(Device):
     def operator(self, path, op, nj, iod, exc):
         try:
             tmpSSD = SSD('ssd', path, self.getDevName())
+            tmpSSD.setInterface(self.getIntfce())
             if op == 'erase':
                 tmpSSD.secureErase()
             if op == 'condition':


### PR DESCRIPTION
Currently, RAID devices assume SSDs with a "None" interface. When NVMe SSDs are used in RAID, this leads to the wrong tool used for secure erase (hdparm instead of nvme).

This change adds support for different interfaces for RAID devices.