### PR TITLE
Do not set password during secure erase of SSDs if drive is locked or secured

### DIFF
--- a/src/perfTest/Devices.py
+++ b/src/perfTest/Devices.py
@@ -14,7 +14,6 @@ from time import sleep
 from fio.FioJob import FioJob
 from system.OS import Storcli
 from system.OS import Mdadm
-from django.test._doctest import master
 
 
 class Device(object):


### PR DESCRIPTION
During some tests of SSDs done by me and my collegues at work disks were left with an enabled security meaning that the password has been set via hdparm but this was (e.g. due to an unhandled exception) not followed by hdparm's secure erase command.

This modified version checks the hdparm output if
- the drive is locked
- the drive is secured
In both cases it is assumed that the (correct) password has already been set and setting the password is skipped.

The version runs without issues since about 6 months and has tested about 20 different SSDs until, so i would assume that it is OK and the change successfully solved the problem...

Today me and my collegues had a meeting with @gschoenberger so he knows a bit about the topic.