### PR TITLE
Added enhancements for drives with a write cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ usage: tkperf [-h] [-v] [-d] [-q] [-nj NUMJOBS] [-iod IODEPTH] [-rt RUNTIME]
               [-i {sas,nvme,fusion}] [-xml] [-rfb] [-dsc DESC_FILE]
               [-c CONFIG] [-ft] [-fm FEATURE_MATRIX] [-hddt {iops,tp}]
               [-ssdt {iops,lat,tp,writesat}] [-m MAIL] [-s SMTP]
-              [-g GEN_REPORT]
+              [-g GEN_REPORT] [-trp RAMPTIME]
               {hdd,ssd,raid} testname device
 
 positional arguments:
@@ -199,6 +199,9 @@ optional arguments:
   -rt RUNTIME, --runtime RUNTIME
                         specify the fio runtime of one test round, if not set
                         this is 60 seconds
+  -trp RAMPTIME, --tpramptime RAMPTIME
+                        specify the fio ramp_time of the first throughput
+                        write test round, if not set this is 30 seconds
   -i {sas,nvme,fusion}, --interface {sas,nvme,fusion}
                         specify optional device interface
   -xml, --fromxml       don't run tests but load test objects from xml file

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ usage: tkperf [-h] [-v] [-d] [-q] [-nj NUMJOBS] [-iod IODEPTH] [-rt RUNTIME]
               [-i {sas,nvme,fusion}] [-xml] [-rfb] [-dsc DESC_FILE]
               [-c CONFIG] [-ft] [-fm FEATURE_MATRIX] [-hddt {iops,tp}]
               [-ssdt {iops,lat,tp,writesat}] [-m MAIL] [-s SMTP]
-              [-g GEN_REPORT] [-trp RAMPTIME]
+              [-g GEN_REPORT] [-trp RAMPTIME] [-tr TESTROUNDS]
               {hdd,ssd,raid} testname device
 
 positional arguments:
@@ -202,6 +202,9 @@ optional arguments:
   -trp RAMPTIME, --tpramptime RAMPTIME
                         specify the fio ramp_time of the first throughput
                         write test round, if not set this is 30 seconds
+  -tr TESTROUNDS, --testrnds TESTROUNDS
+                        specify the maximum number of carried out test rounds,
+                        if not set this is 25
   -i {sas,nvme,fusion}, --interface {sas,nvme,fusion}
                         specify optional device interface
   -xml, --fromxml       don't run tests but load test objects from xml file

--- a/scripts/tkperf
+++ b/scripts/tkperf
@@ -34,6 +34,7 @@ if __name__ == '__main__':
     parser.add_argument("-iod","--iodepth",help="specify iodepth for libaio used by fio",type=int)
     parser.add_argument("-rt","--runtime",help="specify the fio runtime of one test round, if not set this is 60 seconds",type=int)
     parser.add_argument("-trp","--tpramptime",help="specify the fio ramp_time of the first throughput write test round, if not set this is 30 seconds",type=int)
+    parser.add_argument("-tr","--testrnds",help="specify the maximum number of test rounds in a test, if not set this is 25 rounds",type=int)
     parser.add_argument("-i","--interface",help="specify optional device interface",choices=["sas","nvme","fusion","usb","sdcard","compactflash"])
     parser.add_argument("-xml","--fromxml",help="don't run tests but load test objects from xml file",
                         action='store_true')
@@ -86,6 +87,8 @@ if __name__ == '__main__':
         options.setRuntime(args.runtime)
     if args.tpramptime != None:
         options.setTPramptime(args.tpramptime)
+    if args.testrnds != None:
+        options.setTestRnds(args.testrnds)
     if args.refill_buffers == True:
         xargs = ['refill_buffers']
         options.setXargs(xargs)

--- a/scripts/tkperf
+++ b/scripts/tkperf
@@ -33,6 +33,7 @@ if __name__ == '__main__':
     parser.add_argument("-nj","--numjobs",help="specify number of jobs for fio",type=int)
     parser.add_argument("-iod","--iodepth",help="specify iodepth for libaio used by fio",type=int)
     parser.add_argument("-rt","--runtime",help="specify the fio runtime of one test round, if not set this is 60 seconds",type=int)
+    parser.add_argument("-trp","--tpramptime",help="specify the fio ramp_time of the first throughput write test round, if not set this is 30 seconds",type=int)
     parser.add_argument("-i","--interface",help="specify optional device interface",choices=["sas","nvme","fusion","usb","sdcard","compactflash"])
     parser.add_argument("-xml","--fromxml",help="don't run tests but load test objects from xml file",
                         action='store_true')
@@ -83,6 +84,8 @@ if __name__ == '__main__':
         options.setIod(args.iodepth)
     if args.runtime != None:
         options.setRuntime(args.runtime)
+    if args.tpramptime != None:
+        options.setTPramptime(args.tpramptime)
     if args.refill_buffers == True:
         xargs = ['refill_buffers']
         options.setXargs(xargs)

--- a/src/perfTest/DeviceTests.py
+++ b/src/perfTest/DeviceTests.py
@@ -205,7 +205,7 @@ class SsdIopsTest(DeviceTest):
         steadyValues = deque([])#List of 4k random writes IOPS
         xranges = deque([])#Rounds of current measurement window
         
-        for i in range(StdyState.testRnds):
+        for i in range(self.getOptions().getTestRnds()):
             logging.info("#################")
             logging.info("Round nr. "+str(i))
             rndMatrix = self.testRound()
@@ -407,7 +407,7 @@ class SsdLatencyTest(DeviceTest):
         steadyValues = deque([])
         xranges = deque([])#Rounds of current measurement window
         
-        for i in range(StdyState.testRnds):
+        for i in range(self.getOptions().getTestRnds()):
             logging.info("#################")
             logging.info("Round nr. "+str(i))
             rndMatrix = self.testRound()
@@ -645,7 +645,7 @@ class SsdTPTest(DeviceTest):
             logging.info("#################")
             logging.info("Current block size. "+str(j))
             
-            for i in range(StdyState.testRnds):
+            for i in range(self.getOptions().getTestRnds()):
                 logging.info("######")
                 logging.info("Write Round nr. "+str(i))
                 tpWrite = self.testRound("write",j,i)
@@ -671,14 +671,14 @@ class SsdTPTest(DeviceTest):
                         if steadyState == True:
                             logging.info("Reached steady state at round %d",i)
                         #running from 0 to 24
-                        if i == ((StdyState.testRnds) - 1):
+                        if i == ((self.getOptions().getTestRnds()) - 1):
                             self.getStdyState().setReachStdyState(False)
                             logging.warn("#Did not reach steady state for bs %s",j)
                         #In both cases we are done with steady state checking
-                        if steadyState == True or i == ((StdyState.testRnds) - 1):
+                        if steadyState == True or i == ((self.getOptions().getTestRnds()) - 1):
                             #Done with 1M block size
                             break
-            for i in range(StdyState.testRnds):
+            for i in range(self.getOptions().getTestRnds()):
                 logging.info("######")
                 logging.info("Read Round nr. "+str(i))
                 tpRead = self.testRound("read",j,i)

--- a/src/perfTest/DeviceTests.py
+++ b/src/perfTest/DeviceTests.py
@@ -560,12 +560,13 @@ class SsdTPTest(DeviceTest):
         tpWrite = self.getFioJob().getTPWrite(jobOut)
         return [tpRead,tpWrite]
 
-    def testRound(self,rw,bs):
+    def testRound(self,rw,bs, rnd):
         '''
         Carry out one test round of the read or write throughput test.
         Read and Write throughput is tested with the given block size
         @param rw
         @param bs The current block size to use.
+        @param rnd The current round number
         @return Read or Write bandwidths tpRead or tpWrite
         '''
         self.getFioJob().addKVArg("bs",bs)
@@ -587,6 +588,10 @@ class SsdTPTest(DeviceTest):
                 tpWrite = 0 #write bandwidth
                 #start write tests
                 self.getFioJob().addKVArg("rw","write")
+                if rnd == 0:
+                    self.getFioJob().addKVArg("ramp_time",str(self.getOptions().getTPramptime()))
+                else:
+                    self.getFioJob().addKVArg("ramp_time","0")
                 call,jobOut = self.getFioJob().start()
                 if call == False:
                     exit(1)
@@ -622,7 +627,7 @@ class SsdTPTest(DeviceTest):
             for i in range(StdyState.testRnds):
                 logging.info("######")
                 logging.info("Write Round nr. "+str(i))
-                tpWrite = self.testRound("write",j)
+                tpWrite = self.testRound("write",j,i)
                 tpWrite_l.append(tpWrite)
                 
                 #if the rounds have been set by steady state for 1M block size
@@ -655,7 +660,7 @@ class SsdTPTest(DeviceTest):
             for i in range(StdyState.testRnds):
                 logging.info("######")
                 logging.info("Read Round nr. "+str(i))
-                tpRead = self.testRound("read",j)
+                tpRead = self.testRound("read",j,i)
                 tpRead_l.append(tpRead)
 
                 #if the rounds have been set by steady state for 1M block size

--- a/src/perfTest/DeviceTests.py
+++ b/src/perfTest/DeviceTests.py
@@ -236,6 +236,11 @@ class SsdIopsTest(DeviceTest):
             logging.error("# Could not carry out secure erase for "+self.getDevice().getDevPath())
             raise
         try:
+            self.getDevice().logSMARTlog()
+        except RuntimeError:
+            logging.error("# Could not carry out retrieving SMART log for "+self.getDevice().getDevPath())
+            raise
+        try:
             if self.getOptions() == None:
                 self.getDevice().precondition(1,1)
             else:
@@ -252,6 +257,11 @@ class SsdIopsTest(DeviceTest):
         if steadyState == False:
             logging.info("# Steady State has not been reached for IOPS Test.")
         self.toLog()
+        try:
+            self.getDevice().logSMARTlog()
+        except RuntimeError:
+            logging.error("# Could not carry out retrieving SMART log for "+self.getDevice().getDevPath())
+            raise
         return True
 
     def toXml(self,root):
@@ -428,6 +438,12 @@ class SsdLatencyTest(DeviceTest):
             logging.error("# Could not carry out secure erase for "+self.getDevice().getDevPath())
             raise
         try:
+            self.getDevice().logSMARTlog()
+        except RuntimeError:
+            logging.error("# Could not carry out retrieving SMART log for "+self.getDevice().getDevPath())
+            raise
+        return True
+        try:
             if self.__userOptions == None:
                 self.getDevice().precondition(1,1)
             else:
@@ -444,6 +460,11 @@ class SsdLatencyTest(DeviceTest):
         if steadyState == False:
             logging.info("# Steady State has not been reached for Latency Test.")
         self.toLog()
+        try:
+            self.getDevice().logSMARTlog()
+        except RuntimeError:
+            logging.error("# Could not carry out retrieving SMART log for "+self.getDevice().getDevPath())
+            raise
         return True
 
     def toXml(self,root):
@@ -679,10 +700,20 @@ class SsdTPTest(DeviceTest):
         @return True if all tests were run
         '''
         logging.info("########### Starting Throughput Test ###########")
+        try:
+            self.getDevice().logSMARTlog()
+        except RuntimeError:
+            logging.error("# Could not carry out retrieving SMART log for "+self.getDevice().getDevPath())
+            raise
         steadyState = self.runRounds()
         if steadyState == False:
             logging.info("# Steady State has not been reached for Throughput Test.")
         self.toLog()
+        try:
+            self.getDevice().logSMARTlog()
+        except RuntimeError:
+            logging.error("# Could not carry out retrieving SMART log for "+self.getDevice().getDevPath())
+            raise
         return True
 
     def toXml(self,root):
@@ -827,9 +858,19 @@ class SsdWriteSatTest(DeviceTest):
         except RuntimeError:
             logging.error("# Could not carry out secure erase for "+self.getDevice().getDevPath())
             raise
+        try:
+            self.getDevice().logSMARTlog()
+        except RuntimeError:
+            logging.error("# Could not carry out retrieving SMART log for "+self.getDevice().getDevPath())
+            raise
         logging.info("########### Starting Write Saturation Test ###########")
         self.runRounds()
         self.toLog()
+        try:
+            self.getDevice().logSMARTlog()
+        except RuntimeError:
+            logging.error("# Could not carry out retrieving SMART log for "+self.getDevice().getDevPath())
+            raise
         return True
 
     def toXml(self,root):

--- a/src/perfTest/Devices.py
+++ b/src/perfTest/Devices.py
@@ -770,6 +770,7 @@ class SSD(Device):
         job.addKVArg("iodepth",str(iod))
         job.addSglArg("group_reporting")
         job.addSglArg('refill_buffers')
+        job.addKVArg("size",str(round(100/nj))+"%")
 
         for i in range(SSD.wlIndPrecRnds):
             logging.info("# Starting preconditioning round "+str(i))

--- a/src/perfTest/Devices.py
+++ b/src/perfTest/Devices.py
@@ -737,6 +737,20 @@ class SSD(Device):
                     else:
                         return True
 
+    def logSMARTlog(self):
+        '''
+        Log SMART log
+        @return True if nvme smart-log was successful
+        '''
+        out = subprocess.Popen(['nvme', 'smart-log', self.getDevPath() ],stdout=subprocess.PIPE,stderr=subprocess.PIPE,universal_newlines=True)
+        (stdout,stderr) = out.communicate()
+        if out.returncode != 0:
+            logging.error("# Error: nvme smart-log encountered an error: " + stderr)
+            return False
+        else:
+            logging.info("# nvme smartlog: " + stdout)
+            return True
+
     def precondition(self,nj=1,iod=1):
         '''
         Workload independent preconditioning for SSDs.

--- a/src/perfTest/Options.py
+++ b/src/perfTest/Options.py
@@ -13,12 +13,13 @@ class Options(object):
     A class holding user defined options on command line.
     '''
 
-    def __init__(self, nj=1, iod=1, runtime=60, tpramptime=30, xargs=None):
+    def __init__(self, nj=1, iod=1, runtime=60, tpramptime=30, testRounds=25, xargs=None):
         '''
         Constructor
         @param nj Number of jobs
         @param iod Number for io depth
         @param xargs Further argument as list for all fio jobs in tests
+        @param testRounds Maximum number of test rounds in a test
         '''
         ## Number of jobs for fio.
         self.__nj = nj
@@ -30,17 +31,21 @@ class Options(object):
         self.__xargs = xargs
         ## ramp_time of one write test round for fio
         self.__tpramptime = tpramptime
+        ## Max number of carried out test rounds.
+        self.__testRnds = testRounds
 
     def getNj(self): return self.__nj
     def getIod(self): return self.__iod
     def getRuntime(self): return self.__runtime
     def getTPramptime(self): return self.__tpramptime
     def getXargs(self): return self.__xargs
+    def getTestRnds(self): return self.__testRnds
     def setNj(self,nj): self.__nj = nj
     def setIod(self,iod): self.__iod = iod
     def setRuntime(self,rt): self.__runtime = rt
     def setTPramptime(self,ramptime): self.__tpramptime = ramptime
     def setXargs(self,xargs): self.__xargs = xargs
+    def setTestRnds(self,rnds): self.__testRnds = rnds
     
     def appendXml(self,r):
         '''
@@ -63,6 +68,10 @@ class Options(object):
         e = etree.SubElement(r,'tpramptime')
         e.text = data
         
+        data = json.dumps(self.__testRnds)
+        e = etree.SubElement(r,'testrnds')
+        e.text = data
+        
         if self.__xargs != None:
             data = json.dumps(list(self.__xargs))
             e = etree.SubElement(r,'xargs')
@@ -82,6 +91,8 @@ class Options(object):
             self.__runtime = json.loads(root.findtext('runtime'))
         if root.findtext('tpramptime'):
             self.__runtime = json.loads(root.findtext('tpramptime'))
+        if root.findtext('testrnds'):
+            self.__runtime = json.loads(root.findtext('testrnds'))
         if root.findtext('xargs'):
                 self.__xargs = json.loads(root.findtext('xargs'))
         logging.info("# Loading options from xml")

--- a/src/perfTest/Options.py
+++ b/src/perfTest/Options.py
@@ -13,7 +13,7 @@ class Options(object):
     A class holding user defined options on command line.
     '''
 
-    def __init__(self, nj=1, iod=1, runtime=60, xargs=None):
+    def __init__(self, nj=1, iod=1, runtime=60, tpramptime=30, xargs=None):
         '''
         Constructor
         @param nj Number of jobs
@@ -28,14 +28,18 @@ class Options(object):
         self.__runtime = runtime
         ## Further single arguments as list for fio.
         self.__xargs = xargs
+        ## ramp_time of one write test round for fio
+        self.__tpramptime = tpramptime
 
     def getNj(self): return self.__nj
     def getIod(self): return self.__iod
     def getRuntime(self): return self.__runtime
+    def getTPramptime(self): return self.__tpramptime
     def getXargs(self): return self.__xargs
     def setNj(self,nj): self.__nj = nj
     def setIod(self,iod): self.__iod = iod
     def setRuntime(self,rt): self.__runtime = rt
+    def setTPramptime(self,ramptime): self.__tpramptime = ramptime
     def setXargs(self,xargs): self.__xargs = xargs
     
     def appendXml(self,r):
@@ -55,6 +59,10 @@ class Options(object):
         e = etree.SubElement(r,'runtime')
         e.text = data
         
+        data = json.dumps(self.__tpramptime)
+        e = etree.SubElement(r,'tpramptime')
+        e.text = data
+        
         if self.__xargs != None:
             data = json.dumps(list(self.__xargs))
             e = etree.SubElement(r,'xargs')
@@ -72,11 +80,14 @@ class Options(object):
             self.__iod = json.loads(root.findtext('iodepth'))
         if root.findtext('runtime'):
             self.__runtime = json.loads(root.findtext('runtime'))
+        if root.findtext('tpramptime'):
+            self.__runtime = json.loads(root.findtext('tpramptime'))
         if root.findtext('xargs'):
                 self.__xargs = json.loads(root.findtext('xargs'))
         logging.info("# Loading options from xml")
         logging.info("# Options nj:"+str(self.__nj))
         logging.info("# Options iod: "+str(self.__iod))
+        logging.info("# Options tpramptime: "+str(self.__tpramptime))
         if self.__xargs != None:
             logging.info("# Options xargs:")
             logging.info(self.__xargs)

--- a/src/perfTest/StdyState.py
+++ b/src/perfTest/StdyState.py
@@ -13,8 +13,6 @@ class StdyState(object):
     '''
     Used to define a stable state of a device
     '''
-    ## Max number of carried out test rounds.
-    testRnds = 25
     ## Always use a sliding window of 4 to measure performance values.
     testMesWindow = 4
 
@@ -40,6 +38,8 @@ class StdyState(object):
     def getStdyAvg(self): return self.__stdyAvg
     def getStdyValues(self): return self.__stdyValues
     def getStdySlope(self): return self.__stdySlope
+    def getTestRnds(self): return self.__testRnds
+    def setTestRnds(self,rnds): self.__testRnds = rnds
 
     def setReachStdyState(self,s): self.__reachStdyState = s
 

--- a/src/reports/RstReport.py
+++ b/src/reports/RstReport.py
@@ -252,7 +252,7 @@ class RstReport(object):
             if 'lsb' in OSDict:
                 print(" - " + OSDict['lsb'], file=self.__rst)
         
-    def addGeneralInfo(self,testtype):
+    def addGeneralInfo(self,testtype,testrounds):
         '''
         Defines some general used words.
         @param testtype The type of the performance test (ssd,hdd)
@@ -285,7 +285,7 @@ class RstReport(object):
             info.write("for the measurement plots. If the steady state has not been reached after a maximum number of rounds the test ")
             info.write("can be stopped as well. The numbers for these two variables are:\n\n")
             print("- Measurement Window: " + str(StdyState.testMesWindow), file=info)
-            print("- Max. number of rounds: " + str(StdyState.testRnds) + '\n', file=info)
+            print("- Max. number of rounds: " + str(testrounds) + '\n', file=info)
             self.addString(info.getvalue())
             info.close()
     


### PR DESCRIPTION
Added a the following feature that have no impact on the test results, but allow to get to a steady state.

- Changed Throughput runRounds() to run _first all write rounds followed by read rounds_:
Each round was doing a read test followed by a write test. When a drive has a cache it allows to flush during the read. To get more stable results all the writes of all rounds are done first, followed by all reads
- Added command line parameter _Throughput ramp time_ 
If a drive has a write cache it will be filled up during the first write test, to avoid this Throughput ramp time can be specified as a command line parameter.
- Added command line parameter _TestRounds_
The default maximum number of test rounds was 25 and not configurable. This command line parameters allows to modify this. 
- Logging SSD SMART Log before and after each tests
This allows to check if a drive throttled or not during a test
- Corrected SSD preconditioning with 2 or more jobs
The size parameter for fio is per job. A _size=100%_ will write a full drive capacity by each job. 